### PR TITLE
remove duplicative zip

### DIFF
--- a/build/azure-pipeline.yml
+++ b/build/azure-pipeline.yml
@@ -46,7 +46,7 @@ jobs:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Pipeline Artifact'
       inputs:
-        targetPath: firefox/firefox.zip
+        targetPath: firefox/
         artifact: 'firefox-$(version).zip'
 
   - job: ChromeBuild
@@ -66,5 +66,5 @@ jobs:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Pipeline Artifact'
       inputs:
-        targetPath: chrome/chrome.zip
+        targetPath: chrome/
         artifact: 'chrome-$(version).zip'

--- a/build/build-chrome.sh
+++ b/build/build-chrome.sh
@@ -3,4 +3,3 @@
 cd ../chrome
 cp ../icons/*.png .
 cp ../*.js .
-zip chrome *

--- a/build/build-firefox.sh
+++ b/build/build-firefox.sh
@@ -3,4 +3,3 @@
 cd ../firefox
 cp ../icons/*.png .
 cp ../*.js .
-zip firefox *


### PR DESCRIPTION
The build pipeline creates a zip file anyway, no need for a nested one.  This will also take greater advantage of the version specification in the last commit.